### PR TITLE
Rearrange homepage layout

### DIFF
--- a/app/contact/models.py
+++ b/app/contact/models.py
@@ -35,6 +35,8 @@ class Person(Page):
     civicrm_id = models.IntegerField(null=True, blank=True, db_index=True)
 
     content_panels = [
+        FieldPanel("given_name"),
+        FieldPanel("family_name"),
         FieldRowPanel(
             heading="Import metadata",
             help_text="Temporary area for troubleshooting content importers.",
@@ -43,8 +45,6 @@ class Person(Page):
                 FieldPanel("drupal_author_id", permission="superuser"),
             ],
         ),
-        FieldPanel("given_name"),
-        FieldPanel("family_name"),
     ]
 
     template = "contact/contact.html"
@@ -112,14 +112,6 @@ class Meeting(Page):
     drupal_library_author_id = models.IntegerField(null=True, blank=True, db_index=True)
 
     content_panels = Page.content_panels + [
-        FieldRowPanel(
-            heading="Import metadata",
-            help_text="Temporary area for troubleshooting content importers.",
-            children=[
-                FieldPanel("civicrm_id", permission="superuser"),
-                FieldPanel("drupal_author_id", permission="superuser"),
-            ],
-        ),
         FieldPanel("description"),
         FieldPanel("website"),
         FieldPanel("email"),
@@ -129,6 +121,14 @@ class Meeting(Page):
         InlinePanel("addresses", label="Address"),
         InlinePanel(
             "presiding_clerks", label="Presiding clerk", heading="Presiding clerk(s)"
+        ),
+        FieldRowPanel(
+            heading="Import metadata",
+            help_text="Temporary area for troubleshooting content importers.",
+            children=[
+                FieldPanel("civicrm_id", permission="superuser"),
+                FieldPanel("drupal_author_id", permission="superuser"),
+            ],
         ),
     ]
 
@@ -215,6 +215,8 @@ class Organization(Page):
     drupal_library_author_id = models.IntegerField(null=True, blank=True, db_index=True)
 
     content_panels = Page.content_panels + [
+        FieldPanel("description"),
+        FieldPanel("website"),
         FieldRowPanel(
             heading="Import metadata",
             help_text="Temporary area for troubleshooting content importers.",
@@ -223,8 +225,6 @@ class Organization(Page):
                 FieldPanel("drupal_author_id", permission="superuser"),
             ],
         ),
-        FieldPanel("description"),
-        FieldPanel("website"),
     ]
 
     parent_page_types = ["contact.OrganizationIndexPage"]

--- a/app/home/templates/home/home_page.html
+++ b/app/home/templates/home/home_page.html
@@ -10,6 +10,15 @@
     {{ page.intro|richtext }}
 
     <div class="row mt-2">
+        <div class="col">
+            {% if current_issue.featured_articles.count %}
+                <h2>Featured articles</h2>
+                {% for article in current_issue.featured_articles.all %}
+                    {% include "home/home_magazine_article_summary.html" with article=article %}
+                {% endfor %}
+            {% endif %}
+        </div>
+
         <div class="col-sm-4 col-lg-4 col-xl-4 mt-2">
             {% if current_issue %}
                 <a href="{% pageurl current_issue %}" class="home-page-featured-issue">
@@ -22,15 +31,6 @@
                         ({{ current_issue.publication_date | date:"M" }}/{{ current_issue.publication_end_date | date:"M Y" }})
                     {% endif %}
                 </a>
-            {% endif %}
-        </div>
-
-        <div class="col">
-            {% if current_issue.featured_articles.count %}
-                <h2>Featured articles</h2>
-                {% for article in current_issue.featured_articles.all %}
-                    {% include "home/home_magazine_article_summary.html" with article=article %}
-                {% endfor %}
             {% endif %}
         </div>
     </div>

--- a/app/home/templates/home/home_page.html
+++ b/app/home/templates/home/home_page.html
@@ -19,10 +19,10 @@
             {% endif %}
         </div>
 
-        <div class="col-sm-4 col-lg-4 col-xl-4 mt-2">
+        <div class="col-sm-4 col-lg-5 col-xl-5 mt-2">
             {% if current_issue %}
                 <a href="{% pageurl current_issue %}" class="home-page-featured-issue">
-                    {% image current_issue.cover_image max-640x400 %}
+                    {% image current_issue.cover_image max-800x600 %}
                     <br />
                     {{ current_issue.title }}
 

--- a/app/home/templates/home/home_page.html
+++ b/app/home/templates/home/home_page.html
@@ -9,7 +9,7 @@
 
     {{ page.intro|richtext }}
 
-    <div class="row mt-2">
+    <div class="row mt-1">
         <div class="col">
             {% if current_issue.featured_articles.count %}
                 <h2>Featured articles</h2>


### PR DESCRIPTION
Related to #509 

Changes
- swap featured articles and cover photo columns
- adjust spacing between heading elements
- increase cover photo size
- adjust column widths for large and x-large screens