### PR TITLE
Row-card-markup

### DIFF
--- a/app/blocks/templates/blocks/blocks/card_row.html
+++ b/app/blocks/templates/blocks/blocks/card_row.html
@@ -1,7 +1,9 @@
 {% load wagtailcore_tags %}
 
-<div class="row">
+<div class="row mb-3">
     {% for block in self %}
-        {% include_block block %}
+        <div class="col">
+            {% include_block block %}
+        </div>
     {% endfor %}
 </div>

--- a/app/blocks/templates/blocks/blocks/page_card.html
+++ b/app/blocks/templates/blocks/blocks/page_card.html
@@ -1,14 +1,13 @@
-<div class="card col m-1" >
-    <div class="card-body">
-        <p class="card-title">
-            <a href="{{ value.page.url }}">
-                {{ value.page.title }}
-            </a>
-        </p>
-        {% if value.text %}
-            <p class="card-text">
-                {{ value.text }}
-            </p>
-        {% endif %}
-    </div>
+<div class="card" >
+        <div class="card-header">
+            {{ value.page.title }}
+        </div>
+        <div class="card-body">
+            {% if value.text %}
+                <p class="card-text">
+                    {{ value.text }}
+                </p>
+            {% endif %}
+        </div>
+    <a href="{{ value.page.url }}" class="stretched-link"></a>
 </div>


### PR DESCRIPTION
Closes #595

Changes
- move layout classes to parent row
- fix card markup
    - use card header
    - use stretched link

Time
- 2023-04-25: 0.5