### PR TITLE
Include previous query in memorials pagination

### DIFF
--- a/memorials/templates/memorials/memorial_index_page.html
+++ b/memorials/templates/memorials/memorial_index_page.html
@@ -91,7 +91,7 @@
 
             <div class="list-group-item d-flex w-100 justify-content-center mt-2">
                 {% if memorials.has_previous %}
-                    <a href="?page={{ memorials.previous_page_number }}" class="btn btn-outline-primary btn-sm me-2">previous</a>
+                    <a href="?page={{ memorials.previous_page_number }}&{{ request.GET.urlencode }}" class="btn btn-outline-primary btn-sm me-2">previous</a>
                 {% endif %}
 
                 <span class="current">
@@ -99,7 +99,7 @@
                 </span>
 
                 {% if memorials.has_next %}
-                    <a href="?page={{ memorials.next_page_number }}" class="btn btn-outline-primary btn-sm ms-2">next</a>
+                    <a href="?page={{ memorials.next_page_number }}&{{ request.GET.urlencode }}" class="btn btn-outline-primary btn-sm ms-2">next</a>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
Closes #798

Fixes memorials pagination to include any previous querystring so search query is perserved.