### PR TITLE
Replacing ModelAdmin with ModelViewSet

### DIFF
--- a/community/wagtail_hooks.py
+++ b/community/wagtail_hooks.py
@@ -204,12 +204,7 @@ class CommunityGroup(ModelViewSetGroup):
     )
 
 
-community_viewset = CommunityGroup("community")  # defines /admin/community/ as the base URL
-
-
-@hooks.register("register_community_viewset")
-def register_viewset():
-    return community_viewset
+hooks.register("register_community_viewset", CommunityGroup)
 
 
 @hooks.register("insert_editor_js")  # type: ignore

--- a/community/wagtail_hooks.py
+++ b/community/wagtail_hooks.py
@@ -206,6 +206,7 @@ class CommunityGroup(ModelViewSetGroup):
 
 community_viewset = CommunityGroup("community")  # defines /admin/community/ as the base URL
 
+
 @hooks.register("register_community_viewset")
 def register_viewset():
     return community_viewset

--- a/community/wagtail_hooks.py
+++ b/community/wagtail_hooks.py
@@ -1,11 +1,7 @@
 from django.conf import settings
 from django.utils.html import format_html_join
 from django.utils.safestring import SafeString
-from wagtail.contrib.modeladmin.options import (
-    ModelAdmin,
-    ModelAdminGroup,
-    modeladmin_register,
-)
+from wagtail.admin.viewsets.model import ModelViewSet, ModelViewSetGroup
 from wagtail import hooks
 
 from community.models import CommunityDirectory, OnlineWorship
@@ -16,7 +12,7 @@ from memorials.models import Memorial
 from wf_pages.models import MollyWingateBlogPage
 
 
-class PersonModelAdmin(ModelAdmin):
+class PersonViewSet(ModelViewSet):
     model = Person
     menu_icon = "user"
     menu_label = "People"
@@ -35,7 +31,7 @@ class PersonModelAdmin(ModelAdmin):
     # ]
 
 
-class MeetingModelAdmin(ModelAdmin):
+class MeetingViewSet(ModelViewSet):
     model = Meeting
     menu_icon = "home"
     menu_label = "Meetings"
@@ -47,7 +43,7 @@ class MeetingModelAdmin(ModelAdmin):
     list_filter = ("meeting_type",)
 
 
-class OrganizationModelAdmin(ModelAdmin):
+class OrganizationViewSet(ModelViewSet):
     model = Organization
     menu_icon = "group"
     menu_label = "Organizations"
@@ -58,7 +54,7 @@ class OrganizationModelAdmin(ModelAdmin):
     search_fields = ("title",)
 
 
-class MemorialModelAdmin(ModelAdmin):
+class MemorialViewSet(ModelViewSet):
     """Memorial model admin."""
 
     model = Memorial
@@ -79,7 +75,7 @@ class MemorialModelAdmin(ModelAdmin):
     )
 
 
-class MollyWingateBlogPageModelAdmin(ModelAdmin):
+class MollyWingateBlogPageViewSet(ModelViewSet):
     model = MollyWingateBlogPage
     menu_icon = "doc-full"
     menu_label = "Molly Wingate Blog"
@@ -99,7 +95,7 @@ class MollyWingateBlogPageModelAdmin(ModelAdmin):
     )
 
 
-class EventModelAdmin(ModelAdmin):
+class EventViewSet(ModelViewSet):
     model = Event
     menu_icon = "date"
     menu_label = "Events"
@@ -128,7 +124,7 @@ class EventModelAdmin(ModelAdmin):
     )
 
 
-class CommunityDirectoryModelAdmin(ModelAdmin):
+class CommunityDirectoryViewSet(ModelViewSet):
     model = CommunityDirectory
     menu_icon = "group"
     menu_label = "Directories"
@@ -141,7 +137,7 @@ class CommunityDirectoryModelAdmin(ModelAdmin):
     search_fields = ("title",)
 
 
-class OnlineWorshipModelAdmin(ModelAdmin):
+class OnlineWorshipViewSet(ModelViewSet):
     model = OnlineWorship
     menu_icon = "globe"
     menu_label = "Online Worship"
@@ -154,7 +150,7 @@ class OnlineWorshipModelAdmin(ModelAdmin):
     search_fields = ("title",)
 
 
-class PublicBoardDocumentModelAdmin(ModelAdmin):
+class PublicBoardDocumentViewSet(ModelViewSet):
     model = PublicBoardDocument
     menu_icon = "doc-full"
     menu_label = "Public Board Documents"
@@ -167,7 +163,7 @@ class PublicBoardDocumentModelAdmin(ModelAdmin):
     search_fields = ("title",)
 
 
-class MeetingDocumentModelAdmin(ModelAdmin):
+class MeetingDocumentViewSet(ModelViewSet):
     model = MeetingDocument
     menu_icon = "doc-full"
     menu_label = "Meeting Documents"
@@ -190,25 +186,29 @@ class MeetingDocumentModelAdmin(ModelAdmin):
     )
 
 
-class CommunityGroup(ModelAdminGroup):
+class CommunityGroup(ModelViewSetGroup):
     menu_label = "Community"
     menu_icon = "snippet"
     menu_order = 200
     items = (
-        PersonModelAdmin,
-        MeetingModelAdmin,
-        OrganizationModelAdmin,
-        EventModelAdmin,
-        MemorialModelAdmin,
-        CommunityDirectoryModelAdmin,
-        OnlineWorshipModelAdmin,
-        PublicBoardDocumentModelAdmin,
-        MeetingDocumentModelAdmin,
-        MollyWingateBlogPageModelAdmin,
+        PersonViewSet,
+        MeetingViewSet,
+        OrganizationViewSet,
+        EventViewSet,
+        MemorialViewSet,
+        CommunityDirectoryViewSet,
+        OnlineWorshipViewSet,
+        PublicBoardDocumentViewSet,
+        MeetingDocumentViewSet,
+        MollyWingateBlogPageViewSet,
     )
 
 
-modeladmin_register(CommunityGroup)
+community_viewset = CommunityGroup("community")  # defines /admin/community/ as the base URL
+
+@hooks.register("register_community_viewset")
+def register_viewset():
+    return community_viewset
 
 
 @hooks.register("insert_editor_js")  # type: ignore

--- a/library/wagtail_hooks.py
+++ b/library/wagtail_hooks.py
@@ -90,9 +90,4 @@ class LibraryGroup(ModelViewSetGroup):
     )
 
 
-library_viewset = LibraryGroup("library")  # defines /admin/library/ as the base URL
-
-
-@hooks.register("register_library_viewset")
-def register_viewset():
-    return library_viewset
+hooks.register("register_library_viewset", LibraryGroup)

--- a/library/wagtail_hooks.py
+++ b/library/wagtail_hooks.py
@@ -1,14 +1,11 @@
-from wagtail.contrib.modeladmin.options import (
-    ModelAdmin,
-    ModelAdminGroup,
-    modeladmin_register,
-)
+from wagtail.admin.viewsets.model import ModelViewSet, ModelViewSetGroup
+from wagtail import hooks
 
 from facets.models import Audience, Genre, Medium, TimePeriod, Topic
 from library.models import LibraryItem
 
 
-class AudienceModelAdmin(ModelAdmin):
+class AudienceViewSet(ModelViewSet):
     model = Audience
     menu_icon = "tag"
     menu_label = "Audiences"
@@ -17,7 +14,7 @@ class AudienceModelAdmin(ModelAdmin):
     search_fields = "title"
 
 
-class GenreModelAdmin(ModelAdmin):
+class GenreViewSet(ModelViewSet):
     model = Genre
     menu_icon = "tag"
     menu_label = "Genres"
@@ -27,7 +24,7 @@ class GenreModelAdmin(ModelAdmin):
     search_fields = ("title",)
 
 
-class MediumModelAdmin(ModelAdmin):
+class MediumViewSet(ModelViewSet):
     model = Medium
     menu_icon = "tag"
     menu_label = "Mediums"
@@ -37,7 +34,7 @@ class MediumModelAdmin(ModelAdmin):
     search_fields = "title"
 
 
-class TimePeriodModelAdmin(ModelAdmin):
+class TimePeriodViewSet(ModelViewSet):
     model = TimePeriod
     menu_icon = "tag"
     menu_label = "Time Periods"
@@ -47,7 +44,7 @@ class TimePeriodModelAdmin(ModelAdmin):
     search_fields = "title"
 
 
-class TopicModelAdmin(ModelAdmin):
+class TopicViewSet(ModelViewSet):
     model = Topic
     menu_icon = "tag"
     menu_label = "Topics"
@@ -57,7 +54,7 @@ class TopicModelAdmin(ModelAdmin):
     search_fields = "title"
 
 
-class LibraryItemModelAdmin(ModelAdmin):
+class LibraryItemViewSet(ModelViewSet):
     model = LibraryItem
     menu_icon = "list-ul"
     menu_label = "Items"
@@ -79,16 +76,22 @@ class LibraryItemModelAdmin(ModelAdmin):
     search_fields = ("title",)
 
 
-@modeladmin_register
-class LibraryGroup(ModelAdminGroup):
+class LibraryGroup(ModelViewSetGroup):
     menu_label = "Library"
     menu_icon = "clipboard-list"
     menu_order = 200
     items = (
-        LibraryItemModelAdmin,
-        AudienceModelAdmin,
-        GenreModelAdmin,
-        MediumModelAdmin,
-        TimePeriodModelAdmin,
-        TopicModelAdmin,
+        LibraryItemViewSet,
+        AudienceViewSet,
+        GenreViewSet,
+        MediumViewSet,
+        TimePeriodViewSet,
+        TopicViewSet,
     )
+
+
+library_viewset = LibraryGroup("library")  # defines /admin/library/ as the base URL
+
+@hooks.register("register_library_viewset")
+def register_viewset():
+    return library_viewset

--- a/library/wagtail_hooks.py
+++ b/library/wagtail_hooks.py
@@ -92,6 +92,7 @@ class LibraryGroup(ModelViewSetGroup):
 
 library_viewset = LibraryGroup("library")  # defines /admin/library/ as the base URL
 
+
 @hooks.register("register_library_viewset")
 def register_viewset():
     return library_viewset

--- a/magazine/wagtail_hooks.py
+++ b/magazine/wagtail_hooks.py
@@ -186,7 +186,9 @@ class MagazineGroup(ModelViewSetGroup):
         MagazineDepartmentViewSet,
     )
 
+
 magazine_viewset = MagazineGroup("magazine")  # defines /admin/magazine/ as the base URL
+
 
 @hooks.register("register_magazine_viewset")
 def register_viewset():

--- a/magazine/wagtail_hooks.py
+++ b/magazine/wagtail_hooks.py
@@ -187,9 +187,4 @@ class MagazineGroup(ModelViewSetGroup):
     )
 
 
-magazine_viewset = MagazineGroup("magazine")  # defines /admin/magazine/ as the base URL
-
-
-@hooks.register("register_magazine_viewset")
-def register_viewset():
-    return magazine_viewset
+hooks.register("register_magazine_viewset", MagazineGroup)

--- a/magazine/wagtail_hooks.py
+++ b/magazine/wagtail_hooks.py
@@ -2,11 +2,8 @@ from django.urls import reverse
 from django.utils.html import format_html
 from wagtail.contrib.modeladmin.helpers import PageAdminURLHelper, PageButtonHelper
 from wagtail.contrib.modeladmin.mixins import ThumbnailMixin
-from wagtail.contrib.modeladmin.options import (
-    ModelAdmin,
-    ModelAdminGroup,
-    modeladmin_register,
-)
+from wagtail.admin.viewsets.model import ModelViewSet, ModelViewSetGroup
+from wagtail import hooks
 
 from .models import ArchiveIssue, MagazineDepartment, MagazineIssue
 
@@ -92,7 +89,7 @@ class MagazineIssueButtonHelperClass(PageButtonHelper):
         return buttons
 
 
-class MagazineIssueModelAdmin(ThumbnailMixin, ModelAdmin):
+class MagazineIssueViewSet(ThumbnailMixin, ModelViewSet):
     model = MagazineIssue
     menu_icon = "doc-full-inverse"
     menu_label = "Issues"
@@ -147,7 +144,7 @@ class MagazineIssueModelAdmin(ThumbnailMixin, ModelAdmin):
         )
 
 
-class ArchiveIssueModelAdmin(ModelAdmin):
+class ArchiveIssueViewSet(ModelViewSet):
     model = ArchiveIssue
     menu_icon = "doc-full"
     menu_label = "Archive Issues"
@@ -167,7 +164,7 @@ class ArchiveIssueModelAdmin(ModelAdmin):
     )
 
 
-class MagazineDepartmentModelAdmin(ModelAdmin):
+class MagazineDepartmentViewSet(ModelViewSet):
     model = MagazineDepartment
     menu_icon = "tag"
     menu_label = "Departments"
@@ -179,15 +176,18 @@ class MagazineDepartmentModelAdmin(ModelAdmin):
     search_fields = ("title",)
 
 
-class MagazineGroup(ModelAdminGroup):
+class MagazineGroup(ModelViewSetGroup):
     menu_label = "Magazine"
     menu_icon = "tablet-alt"
     menu_order = 100
     items = (
-        MagazineIssueModelAdmin,
-        ArchiveIssueModelAdmin,
-        MagazineDepartmentModelAdmin,
+        MagazineIssueViewSet,
+        ArchiveIssueViewSet,
+        MagazineDepartmentViewSet,
     )
 
+magazine_viewset = MagazineGroup("magazine")  # defines /admin/magazine/ as the base URL
 
-modeladmin_register(MagazineGroup)
+@hooks.register("register_magazine_viewset")
+def register_viewset():
+    return magazine_viewset

--- a/news/wagtail_hooks.py
+++ b/news/wagtail_hooks.py
@@ -55,9 +55,4 @@ class NewsAdminGroup(ModelViewSetGroup):
     )
 
 
-news_viewset = NewsAdminGroup("news")  # defines /admin/news/ as the base URL
-
-
-@hooks.register("register_news_viewset")
-def register_viewset():
-    return news_viewset
+hooks.register("register_news_viewset", NewsAdminGroup)

--- a/news/wagtail_hooks.py
+++ b/news/wagtail_hooks.py
@@ -57,6 +57,7 @@ class NewsAdminGroup(ModelViewSetGroup):
 
 news_viewset = NewsAdminGroup("news")  # defines /admin/news/ as the base URL
 
+
 @hooks.register("register_news_viewset")
 def register_viewset():
     return news_viewset

--- a/news/wagtail_hooks.py
+++ b/news/wagtail_hooks.py
@@ -1,13 +1,10 @@
-from wagtail.contrib.modeladmin.options import (
-    ModelAdmin,
-    ModelAdminGroup,
-    modeladmin_register,
-)
+from wagtail.admin.viewsets.model import ModelViewSet, ModelViewSetGroup
+from wagtail import hooks
 
 from .models import NewsItem, NewsTopic, NewsType
 
 
-class NewsTopicModelAdmin(ModelAdmin):
+class NewsTopicViewSet(ModelViewSet):
     model = NewsTopic
     menu_icon = "tag"
     menu_label = "Topic"
@@ -19,7 +16,7 @@ class NewsTopicModelAdmin(ModelAdmin):
     search_fields = ("title",)
 
 
-class NewsTypeModelAdmin(ModelAdmin):
+class NewsTypeViewSet(ModelViewSet):
     model = NewsType
     menu_icon = "tag"
     menu_label = "Type"
@@ -31,7 +28,7 @@ class NewsTypeModelAdmin(ModelAdmin):
     search_fields = ("title",)
 
 
-class NewsItemModelAdmin(ModelAdmin):
+class NewsItemViewSet(ModelViewSet):
     model = NewsItem
     menu_icon = "list-ul"
     menu_label = "Items"
@@ -47,15 +44,19 @@ class NewsItemModelAdmin(ModelAdmin):
     list_filter = ("publication_date",)
 
 
-class NewsAdminGroup(ModelAdminGroup):
+class NewsAdminGroup(ModelViewSetGroup):
     menu_label = "News"
     menu_icon = "comment"
     menu_order = 300
     items = (
-        NewsItemModelAdmin,
-        NewsTopicModelAdmin,
-        NewsTypeModelAdmin,
+        NewsItemViewSet,
+        NewsTopicViewSet,
+        NewsTypeViewSet,
     )
 
 
-modeladmin_register(NewsAdminGroup)
+news_viewset = NewsAdminGroup("news")  # defines /admin/news/ as the base URL
+
+@hooks.register("register_news_viewset")
+def register_viewset():
+    return news_viewset

--- a/store/wagtail_hooks.py
+++ b/store/wagtail_hooks.py
@@ -1,14 +1,11 @@
-from wagtail.contrib.modeladmin.options import (
-    ModelAdmin,
-    ModelAdminGroup,
-    modeladmin_register,
-)
+from wagtail.admin.viewsets.model import ModelViewSet, ModelViewSetGroup
+from wagtail import hooks
 
 from orders.models import Order
 from store.models import Book
 
 
-class BookModelAdmin(ModelAdmin):
+class BookViewSet(ModelViewSet):
     model = Book
     menu_icon = "openquote"
     menu_label = "Books"
@@ -16,7 +13,7 @@ class BookModelAdmin(ModelAdmin):
     list_display = ("title",)
 
 
-class OrderModelAdmin(ModelAdmin):
+class OrderViewSet(ModelViewSet):
     """Order admin."""
 
     model = Order
@@ -53,14 +50,17 @@ class OrderModelAdmin(ModelAdmin):
     inspect_template_name = "store/inspect_order.html"
 
 
-class StoreGroup(ModelAdminGroup):
+class StoreGroup(ModelViewSetGroup):
     menu_label = "Store"
     menu_icon = "site"
     menu_order = 300
     items = (
-        BookModelAdmin,
-        OrderModelAdmin,
+        BookViewSet,
+        OrderViewSet,
     )
 
+store_viewset = StoreGroup("store")  # defines /admin/store/ as the base URL
 
-modeladmin_register(StoreGroup)
+@hooks.register("register_store_viewset")
+def register_viewset():
+    return store_viewset

--- a/store/wagtail_hooks.py
+++ b/store/wagtail_hooks.py
@@ -60,9 +60,4 @@ class StoreGroup(ModelViewSetGroup):
     )
 
 
-store_viewset = StoreGroup("store")  # defines /admin/store/ as the base URL
-
-
-@hooks.register("register_store_viewset")
-def register_viewset():
-    return store_viewset
+hooks.register("register_store_viewset", StoreGroup)

--- a/store/wagtail_hooks.py
+++ b/store/wagtail_hooks.py
@@ -59,7 +59,9 @@ class StoreGroup(ModelViewSetGroup):
         OrderViewSet,
     )
 
+
 store_viewset = StoreGroup("store")  # defines /admin/store/ as the base URL
+
 
 @hooks.register("register_store_viewset")
 def register_viewset():

--- a/subscription/wagtail_hooks.py
+++ b/subscription/wagtail_hooks.py
@@ -39,6 +39,7 @@ class SubscriptionViewSet(ModelViewSet):
 
 subscription_viewset = SubscriptionViewSet("subscription")  # defines /admin/subscription/ as the base URL
 
+
 @hooks.register("register_subscription_viewset")
 def register_viewset():
     return subscription_viewset

--- a/subscription/wagtail_hooks.py
+++ b/subscription/wagtail_hooks.py
@@ -1,9 +1,10 @@
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail.admin.viewsets.model import ModelViewSet
+from wagtail import hooks
 
 from subscription.models import Subscription
 
 
-class SubscriptionModelAdmin(ModelAdmin):
+class SubscriptionViewSet(ModelViewSet):
     """Subscription admin."""
 
     model = Subscription
@@ -36,4 +37,8 @@ class SubscriptionModelAdmin(ModelAdmin):
     # inspect_template_name = "store/inspect_order.html"
 
 
-modeladmin_register(SubscriptionModelAdmin)
+subscription_viewset = SubscriptionViewSet("subscription")  # defines /admin/subscription/ as the base URL
+
+@hooks.register("register_subscription_viewset")
+def register_viewset():
+    return subscription_viewset

--- a/subscription/wagtail_hooks.py
+++ b/subscription/wagtail_hooks.py
@@ -37,9 +37,4 @@ class SubscriptionViewSet(ModelViewSet):
     # inspect_template_name = "store/inspect_order.html"
 
 
-subscription_viewset = SubscriptionViewSet("subscription")  # defines /admin/subscription/ as the base URL
-
-
-@hooks.register("register_subscription_viewset")
-def register_viewset():
-    return subscription_viewset
+hooks.register("register_subscription_viewset", SubscriptionViewSet)

--- a/tags/wagtail_hooks.py
+++ b/tags/wagtail_hooks.py
@@ -1,9 +1,10 @@
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail.snippets.models import register_snippet
+from wagtail.snippets.views.snippets import SnippetViewSet
 from wagtail.admin.panels import FieldPanel
 from taggit.models import Tag
 
 
-class TagsModelAdmin(ModelAdmin):
+class TagsSnippetViewSet(SnippetViewSet):
     Tag.panels = [
         FieldPanel("name"),
     ]
@@ -18,4 +19,4 @@ class TagsModelAdmin(ModelAdmin):
     search_fields = ("name",)
 
 
-modeladmin_register(TagsModelAdmin)
+register_snippet(TagsSnippetViewSet)


### PR DESCRIPTION
I renamed and replaced `ModelAdmin` and `ModelAdminGroup` with `ModelViewSet` and `ModelViewSetGroup`.
The `Tag` application has `panel` which is not supported in `ModelViewSet` so I used `Snippets` instead.