### PR TITLE
Refactor search query sanitization

### DIFF
--- a/docs/ADRs/0001-search-sanitization.md
+++ b/docs/ADRs/0001-search-sanitization.md
@@ -22,27 +22,33 @@ reusable.)
 
 ## Decision
 
-Replace PostgreSQL tsquery operator characters in user-supplied search queries
-with spaces, in the view layer (`search/views.py`), before the query reaches the
-search backend. The replaced characters are: `( ) & | ! : * \`.
+Replace every character that is not an ASCII letter or digit in user-supplied
+search queries with a space, in the view layer (`search/views.py`), before the
+query reaches the search backend.  This whitelist approach (`[^a-zA-Z0-9]`)
+covers all punctuation, including tsquery operators (`( ) & | ! : * \`) as well
+as other characters such as hyphens and commas that are not operators but are
+equally invalid as standalone tsquery lexemes.
 
 Replacement with a space (rather than deletion) preserves word boundaries, so a
-query like `"foo&bar"` becomes `"foo bar"` (two searchable terms) rather than
+query like `"foo-bar"` becomes `"foo bar"` (two searchable terms) rather than
 `"foobar"` (one unrecognised term).
 
-This is implemented as a compiled regex constant (`_TSQUERY_SPECIAL_CHARS`) and
-applied at the start of the existing sanitization block, alongside the existing
-length and word-count limits. If replacement renders the query empty (e.g. the
-entire input was operators), it is treated as no query (returns no results).
+Digits are kept so that year-qualified queries (`PYM 2025`) work correctly.
+
+This is implemented as a compiled regex constant (`_NON_WORD_CHARS`) and applied
+at the start of the existing sanitization block, alongside the existing length
+and word-count limits.  If replacement renders the query empty (e.g. the entire
+input was punctuation), it is treated as no query (returns no results).
 
 ## Consequences
 
-- **Positive:** Prevents `SyntaxError` crashes for queries containing tsquery
-  operators. Consistent with the project's existing defensive sanitization pattern.
-- **Positive:** Narrow and targeted — only strips characters that are truly
-  problematic for the PostgreSQL backend, preserving hyphens, apostrophes, etc.
-- **Negative:** Users who intentionally type tsquery syntax (e.g., `cat & dog`)
-  will have the operators silently removed. This is acceptable since the search
-  UI does not advertise or support tsquery syntax.
-- **Future:** If `modelsearch` adds proper escaping for these characters in a
-  future version, this sanitization can be removed.
+- **Positive:** Prevents `SyntaxError` crashes for any query containing
+  characters that are invalid as tsquery lexemes. Provably complete — no unknown
+  punctuation can pass through a whitelist.
+- **Positive:** Simpler than a blacklist — one pattern covers all cases, with no
+  risk of missing future problematic characters.
+- **Negative:** Hyphens, apostrophes, and other punctuation that users might
+  type are silently stripped. This is acceptable since the search UI does not
+  advertise or support advanced syntax.
+- **Future:** If `modelsearch` adds proper escaping in a future version, this
+  sanitization can be removed.

--- a/docs/specifications/search_optimization.md
+++ b/docs/specifications/search_optimization.md
@@ -127,11 +127,11 @@ The full query sanitization pipeline executes in this order:
 
 ```text
 raw query string
-  → strip tsquery special characters       (§1)
-  → truncate to MAX_QUERY_LENGTH chars      (§2)
+  → replace all non-alphanumeric characters with spaces  (§1)
+  → truncate to MAX_QUERY_LENGTH chars                   (§2)
   → split into words
-  → remove stopwords                        (§3)
-  → truncate to MAX_QUERY_WORDS words       (§2)
+  → remove stopwords                                     (§3)
+  → truncate to MAX_QUERY_WORDS words                    (§2)
   → rejoin into sanitised query string
 ```
 

--- a/docs/specifications/search_optimization.md
+++ b/docs/specifications/search_optimization.md
@@ -11,21 +11,23 @@ Related ADRs: [ADR 0001](../ADRs/0001-search-sanitization.md) ·
 
 ---
 
-## 1. Special-Character Sanitization
+## 1. Non-Alphanumeric Character Sanitization
 
 **ADR:** [0001](../ADRs/0001-search-sanitization.md)
 
-PostgreSQL `tsquery` syntax operators (`( ) & | ! : * \`) are stripped from
-user-supplied queries and replaced with spaces before the query reaches the
-search backend. Replacement with a space (rather than deletion) preserves word
-boundaries so that `"foo&bar"` becomes two searchable terms (`foo bar`) rather
-than one (`foobar`).
+Every character that is not an ASCII letter or digit is replaced with a space
+before the query reaches the search backend.  This whitelist approach covers all
+tsquery operators (`( ) & | ! : * \`) as well as any other punctuation (hyphens,
+commas, etc.) that the PostgreSQL `modelsearch` backend cannot safely convert to
+a tsquery lexeme.  Replacement with a space preserves word boundaries so that
+`"foo-bar"` becomes two searchable terms (`foo bar`) rather than one (`foobar`).
+Digits are preserved so that year-qualified queries such as `PYM 2025` work.
 
-If the entire query consists of operator characters, the sanitised result is
-empty and is treated as no query (returns no results).
+If the entire query consists of non-alphanumeric characters, the sanitised
+result is empty and is treated as no query (returns no results).
 
-**Implementation:** `_TSQUERY_SPECIAL_CHARS` compiled regex constant applied via
-`.sub(" ", search_query).strip()`.
+**Implementation:** `_NON_WORD_CHARS` compiled regex constant (`[^a-zA-Z0-9]`)
+applied via `.sub(" ", search_query).strip()`.
 
 ---
 

--- a/search/tests.py
+++ b/search/tests.py
@@ -738,26 +738,57 @@ class SearchQueryLimitTestCase(TestCase):
         self.assertEqual(response.context["search_query"], exactly_max)
 
     def test_query_with_tsquery_special_chars_is_sanitized(self) -> None:
-        """Queries with tsquery operators should not crash with a PostgreSQL SyntaxError."""
+        """Queries with non-alphanumeric characters should not crash with a PostgreSQL SyntaxError."""
         response = self.client.get(
             reverse("search"),
             {"query": "What type(s) of damage(s) may"},
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        for char in r"()&|!:*\\":
-            self.assertNotIn(char, response.context["search_query"])
+        import re
+
+        self.assertIsNone(
+            re.search(r"[^a-zA-Z0-9 ]", response.context["search_query"]),
+            "search_query should contain only letters, digits, and spaces",
+        )
 
     def test_special_chars_replaced_with_spaces_preserving_word_boundaries(
         self,
     ) -> None:
-        """Operator chars between words must become spaces, not be deleted.
+        """Non-alphanumeric chars between words must become spaces, not be deleted.
 
-        "foo&bar" should sanitize to "foo bar" (two terms), not "foobar" (one
-        unrecognised term), so both words remain searchable.
+        "foo&bar" and "foo-bar" should each sanitize to "foo bar" (two terms),
+        not "foobar" (one unrecognised term), so both words remain searchable.
         """
         response = self.client.get(reverse("search"), {"query": "foo&bar"})
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context["search_query"], "foo bar")
+
+        response = self.client.get(reverse("search"), {"query": "foo-bar"})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.context["search_query"], "foo bar")
+
+    def test_hyphen_only_word_does_not_crash(self) -> None:
+        """Regression: a hyphen token surviving sanitization caused tsquery SyntaxError.
+
+        Real query: "Urban heat islandsTR Oke - The Routledge Handbook of urban
+        ecology, 2011".  The hyphen was not in the old blacklist, survived into
+        a Wagtail Lexeme, and PostgreSQL rejected the empty lexeme with
+        ProgrammingError: syntax error in tsquery.
+        """
+        response = self.client.get(
+            reverse("search"),
+            {
+                "query": "Urban heat islandsTR Oke - The Routledge Handbook of urban ecology, 2011",
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        import re
+
+        if response.context["search_query"] is not None:
+            self.assertIsNone(
+                re.search(r"[^a-zA-Z0-9 ]", response.context["search_query"]),
+                "search_query should contain only letters, digits, and spaces",
+            )
 
     def test_query_of_only_special_chars_returns_no_results(self) -> None:
         """A query that reduces to empty after stripping should show no results."""

--- a/search/tests.py
+++ b/search/tests.py
@@ -784,11 +784,14 @@ class SearchQueryLimitTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         import re
 
-        if response.context["search_query"] is not None:
-            self.assertIsNone(
-                re.search(r"[^a-zA-Z0-9 ]", response.context["search_query"]),
-                "search_query should contain only letters, digits, and spaces",
-            )
+        self.assertIsNotNone(
+            response.context["search_query"],
+            "sanitization of a mixed query should produce a non-empty search_query",
+        )
+        self.assertIsNone(
+            re.search(r"[^a-zA-Z0-9 ]", response.context["search_query"]),
+            "search_query should contain only letters, digits, and spaces",
+        )
 
     def test_query_of_only_special_chars_returns_no_results(self) -> None:
         """A query that reduces to empty after stripping should show no results."""

--- a/search/views.py
+++ b/search/views.py
@@ -11,9 +11,11 @@ from pagination.helpers import get_paginated_items
 MAX_QUERY_LENGTH = 30  # characters
 MAX_QUERY_WORDS = 5  # words
 
-# PostgreSQL tsquery treats these as syntax operators; replace them with spaces
-# to preserve word boundaries (e.g. "foo&bar" → "foo bar", not "foobar")
-_TSQUERY_SPECIAL_CHARS = re.compile(r"[()&|!:*\\]")
+# Only ASCII letters and digits are safe tsquery lexeme characters.  Replace
+# everything else with a space to preserve word boundaries
+# (e.g. "foo-bar" → "foo bar", not "foobar").  Using a whitelist rather than
+# a blacklist means no punctuation character can ever produce an invalid lexeme.
+_NON_WORD_CHARS = re.compile(r"[^a-zA-Z0-9]")
 
 # PostgreSQL English full-text search stopwords (pg_catalog.english).
 # These words are discarded by the FTS engine before indexing and querying, so
@@ -167,8 +169,8 @@ def search(request: HttpRequest) -> HttpResponse:
 
     # Sanitize query to prevent runaway tsquery complexity with OR operator
     if search_query:
-        # Strip PostgreSQL tsquery special characters to prevent syntax errors
-        search_query = _TSQUERY_SPECIAL_CHARS.sub(" ", search_query).strip() or None
+        # Strip non-alphanumeric characters to prevent tsquery syntax errors
+        search_query = _NON_WORD_CHARS.sub(" ", search_query).strip() or None
         if search_query:
             if len(search_query) > MAX_QUERY_LENGTH:
                 search_query = search_query[:MAX_QUERY_LENGTH]


### PR DESCRIPTION
Enhance input handling by replacing non-alphanumeric characters with spaces in user-supplied search queries, preserving word boundaries before the query reaches the search backend. This change prevents potential syntax errors and improves overall query processing.

## Summary by Sourcery

Broaden search query sanitization to replace all non-alphanumeric characters with spaces before queries reach the backend, preventing tsquery syntax errors while preserving word boundaries.

Bug Fixes:
- Ensure queries containing previously unhandled punctuation such as hyphens no longer trigger PostgreSQL tsquery syntax errors.

Enhancements:
- Tighten search input sanitization to a whitelist of ASCII letters and digits, standardizing how punctuation is removed while preserving word boundaries for search terms.

Documentation:
- Update ADR and search optimization documentation to describe the new non-alphanumeric character sanitization strategy and its rationale.
- Clarify documented examples of how queries like "foo-bar" are normalized and how digit-containing queries (e.g. year-qualified searches) are handled.

Tests:
- Expand search sanitization tests to assert that only letters, digits, and spaces survive, add coverage for hyphenated queries, and add a regression test for a real-world hyphen-related failure case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search input sanitization now converts non-alphanumeric characters (e.g., hyphens, punctuation) to spaces, improving word-boundary preservation and more consistent results.

* **Documentation**
  * Updated architecture decision record and search specification to describe the revised sanitization and empty-query behavior.

* **Tests**
  * Search tests updated to assert preservation of letters/digits and spacing for inputs like "foo-bar".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->